### PR TITLE
Add tox for buildng venv and running tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 ---
 language: python
 dist: trusty
-python:
-  - "2.7"
-  - "3.6"
-install: pip install -r requirements.txt -r requirements-dev.txt
+matrix:
+  include:
+    - python: 3.6
+      env: TOXENV=py3
+    - python: 2.7
+      env: TOXENV=py27
+
+install: pip install tox
 script: make test

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,7 @@ export PATH := venv/bin/:$(PATH)
 all: venv
 
 venv:
-	virtualenv -p python3.6 venv
-	pip install -r requirements-dev.txt -r requirements.txt -e .
+	tox -e venv
 	pre-commit install --install-hooks
 
 .PHONY: clean
@@ -13,6 +12,4 @@ clean:
 
 .PHONY: test
 test:
-	pre-commit run --all-files
-	pytest tests
-	pylint devdocs_cli tests
+	tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,16 @@
+[tox]
+envlist = py27,py3
+usedevelop = True
+
+[testenv]
+deps=
+    -rrequirements.txt
+    -rrequirements-dev.txt
+commands =
+    pre-commit run --all-files
+    pytest tests
+    pylint devdocs_cli tests
+
+[testenv:venv]
+envdir = venv
+commands =


### PR DESCRIPTION
Planning on supporting multiple versions of python so set tox up so running the tests on both are easier.